### PR TITLE
Dfi 2112 task list page update

### DIFF
--- a/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
@@ -41,7 +41,10 @@ trait BasePage extends Matchers with PageObject {
   val confirmAndSaveButton: By               = By.xpath("//button[contains(text(),'Confirm and save')]")
   val confirmAndSaveButtonForOrgDetails: By  =
     By.cssSelector("a.govuk-button[href='/obligations/enrolment/isa/task-list']")
-  val taskStatus: By                         = By.id("task-list-1-status")
+
+  def taskStatusLocator(taskName: String): By = {
+    By.xpath(s"//li[.//a[normalize-space(text())='$taskName']]//div[contains(@class, 'govuk-task-list__status')]")
+  }
 
   def verifyPageUrl(): Boolean =
     getCurrentUrl == pageUrl
@@ -68,14 +71,9 @@ trait BasePage extends Matchers with PageObject {
     }
   }
 
-  def verifyTaskStatus(pageTaskStatus: String): Boolean = {
-    val actualStatus = getText(taskStatus)
-    if (actualStatus != pageTaskStatus) {
-      println(s"[Header Mismatch] Expected: '$pageTaskStatus' | Actual: '$actualStatus'")
-      false
-    } else {
-      true
-    }
+  def verifyTaskStatus(taskName: String, expectedStatus: String): Unit = {
+    val actualStatus = getText(taskStatusLocator(taskName))
+    actualStatus should include (expectedStatus)
   }
 
   private def fluentWait: Wait[WebDriver] = new FluentWait[WebDriver](Driver.instance)

--- a/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
@@ -42,9 +42,8 @@ trait BasePage extends Matchers with PageObject {
   val confirmAndSaveButtonForOrgDetails: By  =
     By.cssSelector("a.govuk-button[href='/obligations/enrolment/isa/task-list']")
 
-  def taskStatusLocator(taskName: String): By = {
+  def taskStatusLocator(taskName: String): By =
     By.xpath(s"//li[.//a[normalize-space(text())='$taskName']]//div[contains(@class, 'govuk-task-list__status')]")
-  }
 
   def verifyPageUrl(): Boolean =
     getCurrentUrl == pageUrl
@@ -73,7 +72,7 @@ trait BasePage extends Matchers with PageObject {
 
   def verifyTaskStatus(taskName: String, expectedStatus: String): Unit = {
     val actualStatus = getText(taskStatusLocator(taskName))
-    actualStatus should include (expectedStatus)
+    actualStatus should include(expectedStatus)
   }
 
   private def fluentWait: Wait[WebDriver] = new FluentWait[WebDriver](Driver.instance)

--- a/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
@@ -39,6 +39,8 @@ trait BasePage extends Matchers with PageObject {
   val signOutButton: By                      = By.xpath("//a[contains(text(),'Sign out')]")
   val pageHeader: By                         = By.xpath("//h1")
   val confirmAndSaveButton: By               = By.xpath("//button[contains(text(),'Confirm and save')]")
+  val confirmAndSaveButtonForOrgDetails: By  =
+    By.cssSelector("a.govuk-button[href='/obligations/enrolment/isa/task-list']")
 
   def verifyPageUrl(): Boolean =
     getCurrentUrl == pageUrl
@@ -83,10 +85,8 @@ trait BasePage extends Matchers with PageObject {
   def enterText(id: String, textToEnter: String): Unit =
     sendKeys(By.id(id), textToEnter)
 
-  def clickOnByPartialLinkText(partialLinkText: String): Unit = {
-    verifyPageLoaded()
+  def clickOnByPartialLinkText(partialLinkText: String): Unit =
     click(By.partialLinkText(partialLinkText))
-  }
 
   def clickOnLinks(button: String): Unit = {
     val locator = By.xpath(s"//*[contains(@href, '$button')]")
@@ -107,6 +107,9 @@ trait BasePage extends Matchers with PageObject {
 
   def clickConfirmAndSave(): Unit =
     click(confirmAndSaveButton)
+
+  def clickConfirmAndSaveForCheckOrgDetails(): Unit =
+    click(confirmAndSaveButtonForOrgDetails)
 
   def clickContinue(): Unit =
     click(continueButton)

--- a/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/pages/BasePage.scala
@@ -41,6 +41,7 @@ trait BasePage extends Matchers with PageObject {
   val confirmAndSaveButton: By               = By.xpath("//button[contains(text(),'Confirm and save')]")
   val confirmAndSaveButtonForOrgDetails: By  =
     By.cssSelector("a.govuk-button[href='/obligations/enrolment/isa/task-list']")
+  val taskStatus: By                         = By.id("task-list-1-status")
 
   def verifyPageUrl(): Boolean =
     getCurrentUrl == pageUrl
@@ -61,6 +62,16 @@ trait BasePage extends Matchers with PageObject {
     val actualHeader = getText(pageHeader)
     if (actualHeader != pageHeaderText) {
       println(s"[Header Mismatch] Expected: '$pageHeaderText' | Actual: '$actualHeader'")
+      false
+    } else {
+      true
+    }
+  }
+
+  def verifyTaskStatus(pageTaskStatus: String): Boolean = {
+    val actualStatus = getText(taskStatus)
+    if (actualStatus != pageTaskStatus) {
+      println(s"[Header Mismatch] Expected: '$pageTaskStatus' | Actual: '$actualStatus'")
       false
     } else {
       true

--- a/src/test/scala/uk/gov/hmrc/ui/disa/pages/TaskListPage.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/pages/TaskListPage.scala
@@ -20,7 +20,7 @@ import org.openqa.selenium.By
 
 object TaskListPage extends BasePage {
   val pageUrl: String   = s"$baseUrl/task-list"
-  val pageTitle: String = "Task List - Manage ISAs - GOV.UK"
+  val pageTitle: String = "Manage ISAs - Manage ISAs - GOV.UK"
 
   def clickSignatories(): Unit =
     click(By.linkText("Signatories"))

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddAnotherAddressForYourOrganisationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddAnotherAddressForYourOrganisationSpec.scala
@@ -36,7 +36,7 @@ class AddAnotherAddressForYourOrganisationSpec extends BaseSpec {
       AuthLoginPage.navigateTo(RegisteredAddressCorrespondencePage.pageUrl)
 
       Then(
-        "the user clicks on the No radio button and then clicks on save and continue buttonon 'registered-address-correspondence' page"
+        "the user clicks on the No radio button and then clicks on save and continue button 'registered-address-correspondence' page"
       )
       RegisteredAddressCorrespondencePage.clickRadioButton("No")
       RegisteredAddressCorrespondencePage.clickSaveAndContinue()

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddLiaisonOfficerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddLiaisonOfficerSpec.scala
@@ -29,8 +29,11 @@ class AddLiaisonOfficerSpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'liaison officer name' page")
-      AuthLoginPage.navigateTo(LiaisonOfficerNamePage.pageUrl)
+      Then(
+        "the 'Add liaison officers' status is 'Not yet started' the user clicks on the 'Add liaison officers' link"
+      )
+      TaskListPage.verifyTaskStatus("Add liaison officers", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add liaison officers")
 
       Then("the user is navigated to the 'liaison-officer-name' page")
       LiaisonOfficerNamePage.verifyPageTitle(
@@ -116,7 +119,7 @@ class AddLiaisonOfficerSpec extends BaseSpec {
         CheckAddedLiaisonOfficerPage.pageUrl
       ) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
+      /*  When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
       Then("the user is navigated to the 'Check your answers' page")
@@ -161,7 +164,7 @@ class AddLiaisonOfficerSpec extends BaseSpec {
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+      ) shouldBe true*/
 
     }
 
@@ -172,8 +175,11 @@ class AddLiaisonOfficerSpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'liaison officer name' page")
-      LiaisonOfficerNamePage.navigateTo(LiaisonOfficerNamePage.pageUrl)
+      Then(
+        "the 'Add liaison officers' status is 'Not yet started' the user clicks on the 'Add liaison officers' link"
+      )
+      TaskListPage.verifyTaskStatus("Add liaison officers", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add liaison officers")
 
       Then("the user is navigated to the 'liaison-officer-name' page")
       LiaisonOfficerNamePage.verifyPageTitle(
@@ -333,7 +339,20 @@ class AddLiaisonOfficerSpec extends BaseSpec {
         AddedLiaisonOfficersPage.pageUrl
       ) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
+      Then("the user clicks on no radio button on 'added-liaison-officer' page ")
+      AddedLiaisonOfficersPage.clickRadioButton("No")
+
+      Then("the user clicks on Save and continue button on 'added-liaison-officer' page ")
+      AddedLiaisonOfficersPage.clickSaveAndContinue()
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      And("The status for 'Change liaison officers' is '1 liaison officer'")
+      TaskListPage.verifyTaskStatus("Change liaison officers", "1 liaison officer")
+
+      // Below steps to be commented out for now and will be later used in E2E test case
+      /*  When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
       Then("the user is navigated to the 'Check your answers' page")
@@ -420,7 +439,7 @@ class AddLiaisonOfficerSpec extends BaseSpec {
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+      ) shouldBe true*/
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
@@ -29,7 +29,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       Given("the user is logged in as an organisation User")
       AuthLoginPage.loginAsAFreshUser("/start")
 
-      Then("the user is navigated to the 'Task list' page")
+      Then("the user is navigated to the 'Manage ISAs' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
       When("the user navigates to the 'Registered ISA Manager' page")
@@ -151,7 +151,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       OrganisationTelephoneNumberPage.enterText("value", "07777 777 777")
       OrganisationTelephoneNumberPage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
@@ -170,7 +170,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeOrganisationTradingNamePage.enterText("value", "Changed Trading org")
       ChangeOrganisationTradingNamePage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
@@ -189,7 +189,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeOrganisationTradingNamePage.enterText("value", "9992299")
       ChangeOrganisationTradingNamePage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
@@ -208,20 +208,20 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeOrganisationTelephoneNumberPage.enterText("value", "07777777777")
       ChangeOrganisationTelephoneNumberPage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
       ) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
-      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
-
-      Then("the user is navigated to the 'Check your answers' page")
-      CheckYourAnswersPage.verifyPageTitle(
-        CheckYourAnswersPage.pageTitle,
-        CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+//      When("the user navigates to the 'Check your answers' page")
+//      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
+//
+//      Then("the user is navigated to the 'Check your answers' page")
+//      CheckYourAnswersPage.verifyPageTitle(
+//        CheckYourAnswersPage.pageTitle,
+//        CheckYourAnswersPage.pageUrl
+//      ) shouldBe true
 
       When("the user clicks on change link for Change Trading name")
       CheckYourAnswersPage.clickOnLinks("change-trading-name")
@@ -236,10 +236,10 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeOrganisationTradingNamePage.enterText("value", "Trading org")
       ChangeOrganisationTradingNamePage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Check your answers' page")
-      CheckYourAnswersPage.verifyPageTitle(
-        CheckYourAnswersPage.pageTitle,
-        CheckYourAnswersPage.pageUrl
+      Then("the user is navigated to the 'Check your organisation details' page")
+      OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
+        OrganisationDetailsCheckYourAnswersPage.pageTitle,
+        OrganisationDetailsCheckYourAnswersPage.pageUrl
       ) shouldBe true
 
       When("the user clicks on change link for Change FCA number")
@@ -255,11 +255,11 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeOrganisationTradingNamePage.enterText("value", "9992299")
       ChangeOrganisationTradingNamePage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Check your answers' page")
-      CheckYourAnswersPage.verifyPageTitle(
-        CheckYourAnswersPage.pageTitle,
-        CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+//      Then("the user is navigated to the 'Check your answers' page")
+//      CheckYourAnswersPage.verifyPageTitle(
+//        CheckYourAnswersPage.pageTitle,
+//        CheckYourAnswersPage.pageUrl
+//      ) shouldBe true
 
       When("the user clicks on change link for Change organisation Telephone number")
       CheckYourAnswersPage.clickOnLinks("change-organisation-telephone-number")
@@ -274,11 +274,17 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeOrganisationTelephoneNumberPage.enterText("value", "07777777777")
       ChangeOrganisationTelephoneNumberPage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Check your answers' page")
-      CheckYourAnswersPage.verifyPageTitle(
-        CheckYourAnswersPage.pageTitle,
-        CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+//      Then("the user is navigated to the 'Check your answers' page")
+//      CheckYourAnswersPage.verifyPageTitle(
+//        CheckYourAnswersPage.pageTitle,
+//        CheckYourAnswersPage.pageUrl
+//      ) shouldBe true
+
+      Then("the user clicks on Save and Continue on the Check your organisation details page")
+      OrganisationDetailsCheckYourAnswersPage.clickConfirmAndSaveForCheckOrgDetails()
+
+      Then("the user clicks on is navigated to the 'Manage ISAs' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
     }
 
@@ -402,7 +408,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       OrganisationTelephoneNumberPage.enterText("value", "07777 777 777")
       OrganisationTelephoneNumberPage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
@@ -433,7 +439,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       OrganisationZReferenceNumberPage.enterText("value", "Z1234")
       OrganisationZReferenceNumberPage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
@@ -462,7 +468,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       OrganisationTradingNamePage.enterText("value", "Trading name")
       OrganisationTradingNamePage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
@@ -481,12 +487,17 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeRegisteredAddressCorrespondencePage.clickRadioButton("Yes")
       ChangeRegisteredAddressCorrespondencePage.clickSaveAndContinue()
 
-      Then("the user is navigated to the 'Organisation details check your answers' page")
+      Then("the user is navigated to the 'Check your organisation details' page")
       OrganisationDetailsCheckYourAnswersPage.verifyPageTitle(
         OrganisationDetailsCheckYourAnswersPage.pageTitle,
         OrganisationDetailsCheckYourAnswersPage.pageUrl
       ) shouldBe true
 
+      Then("the user clicks on Save and Continue on the Check your organisation details page")
+      OrganisationDetailsCheckYourAnswersPage.clickConfirmAndSaveForCheckOrgDetails()
+
+      Then("the user clicks on is navigated to the 'Manage ISAs' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
@@ -35,8 +35,8 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       When(
         "the 'Add organisation information' status is 'Not yet started' the user navigates to the 'Add organisation information' page"
       )
-      TaskListPage.verifyTaskStatus("Add organisation information" ,"Not yet started")
-      AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
+      TaskListPage.verifyTaskStatus("Add organisation information", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add organisation information")
 
       Then("the user is navigated to the 'Registered ISA Manager' page")
       RegisteredIsaManagerPage.verifyPageTitle(
@@ -291,7 +291,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
       And("the 'Change organisation information' status is 'Completed'")
-      TaskListPage.verifyTaskStatus("Change organisation information" ,"Completed")
+      TaskListPage.verifyTaskStatus("Change organisation information", "Completed")
 
     }
 
@@ -308,8 +308,9 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       When(
         "the 'Add organisation information' status is 'Not yet started' the user navigates to the 'Add organisation information' page"
       )
-      TaskListPage.verifyTaskStatus("Add organisation information" ,"Not yet started")
-      AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
+      TaskListPage.verifyTaskStatus("Add organisation information", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add organisation information")
+//      AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
 
       // Navigation to the REgistered ISA Manager page is handled in the above code
 //      When("the user navigates to the 'Registered ISA Manager' page")
@@ -514,7 +515,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
       And("the 'Change organisation information' status is 'Completed'")
-      TaskListPage.verifyTaskStatus("Change organisation information" ,"Completed")
+      TaskListPage.verifyTaskStatus("Change organisation information", "Completed")
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
@@ -29,11 +29,11 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       Given("the user is logged in as an organisation User")
       AuthLoginPage.loginAsAFreshUser("/start")
 
-      Then("the user is navigated to the 'Manage ISAs' page")
+      Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When(
-        "the 'Add organisation information' status is 'Not yet started' the user navigates to the 'Add organisation information' page"
+      Then(
+        "the 'Add organisation information' status is 'Not yet started' the user clicks on the 'Add organisation information' link"
       )
       TaskListPage.verifyTaskStatus("Add organisation information", "Not yet started")
       TaskListPage.clickOnByPartialLinkText("Add organisation information")
@@ -217,14 +217,25 @@ class AddOrganisationDetailsSpec extends BaseSpec {
         OrganisationDetailsCheckYourAnswersPage.pageUrl
       ) shouldBe true
 
-//      When("the user navigates to the 'Check your answers' page")
-//      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
-//
-//      Then("the user is navigated to the 'Check your answers' page")
-//      CheckYourAnswersPage.verifyPageTitle(
-//        CheckYourAnswersPage.pageTitle,
-//        CheckYourAnswersPage.pageUrl
-//      ) shouldBe true
+      Then("the user clicks on Save and Continue on the Check your organisation details page")
+      OrganisationDetailsCheckYourAnswersPage.clickConfirmAndSaveForCheckOrgDetails()
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      And("The status for organisation  status is 'Completed'")
+      TaskListPage.verifyTaskStatus("Change organisation information", "Completed")
+
+      // below steps to be used in E2E test with nav in place
+
+      /*When("the user navigates to the 'Check your answers' page")
+      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
+
+      Then("the user is navigated to the 'Check your answers' page")
+      CheckYourAnswersPage.verifyPageTitle(
+       CheckYourAnswersPage.pageTitle,
+       CheckYourAnswersPage.pageUrl
+      ) shouldBe true
 
       When("the user clicks on change link for Change Trading name")
       CheckYourAnswersPage.clickOnLinks("change-trading-name")
@@ -258,40 +269,33 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       ChangeOrganisationTradingNamePage.enterText("value", "9992299")
       ChangeOrganisationTradingNamePage.clickSaveAndContinue()
 
-//      Then("the user is navigated to the 'Check your answers' page")
-//      CheckYourAnswersPage.verifyPageTitle(
-//        CheckYourAnswersPage.pageTitle,
-//        CheckYourAnswersPage.pageUrl
-//      ) shouldBe true
+      Then("the user is navigated to the 'Check your answers' page")
+      CheckYourAnswersPage.verifyPageTitle(
+       CheckYourAnswersPage.pageTitle,
+        CheckYourAnswersPage.pageUrl
+     ) shouldBe true
 
-      // IS A DUPLICATED TEST: there is a test above which changes the phone number already
-//      When("the user clicks on change link for Change organisation Telephone number")
-//      CheckYourAnswersPage.clickOnLinks("change-organisation-telephone-number")
-//
-//      Then("the user is navigated to the 'change-organisation-telephone-number' page")
-//      ChangeOrganisationTelephoneNumberPage.verifyPageTitle(
-//        ChangeOrganisationTelephoneNumberPage.pageTitle,
-//        ChangeOrganisationTelephoneNumberPage.pageUrl
-//      ) shouldBe true
-//
-//      Then("the user changes the organisation telephone number")
-//      ChangeOrganisationTelephoneNumberPage.enterText("value", "07777777777")
-//      ChangeOrganisationTelephoneNumberPage.clickSaveAndContinue()
+      When("the user clicks on change link for Change organisation Telephone number")
+      CheckYourAnswersPage.clickOnLinks("change-organisation-telephone-number")
 
-//      Then("the user is navigated to the 'Check your answers' page")
-//      CheckYourAnswersPage.verifyPageTitle(
-//        CheckYourAnswersPage.pageTitle,
-//        CheckYourAnswersPage.pageUrl
-//      ) shouldBe true
+      Then("the user is navigated to the 'change-organisation-telephone-number' page")
+      ChangeOrganisationTelephoneNumberPage.verifyPageTitle(
+       ChangeOrganisationTelephoneNumberPage.pageTitle,
+       ChangeOrganisationTelephoneNumberPage.pageUrl
+      ) shouldBe true
+
+      Then("the user changes the organisation telephone number")
+      ChangeOrganisationTelephoneNumberPage.enterText("value", "07777777777")
+      ChangeOrganisationTelephoneNumberPage.clickSaveAndContinue()
+
+      Then("the user is navigated to the 'Check your answers' page")
+      CheckYourAnswersPage.verifyPageTitle(
+      CheckYourAnswersPage.pageTitle,
+       CheckYourAnswersPage.pageUrl
+    ) shouldBe true
 
       Then("the user clicks on Save and Continue on the Check your organisation details page")
-      OrganisationDetailsCheckYourAnswersPage.clickConfirmAndSaveForCheckOrgDetails()
-
-      Then("the user clicks on is navigated to the 'Manage ISAs' page")
-      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
-
-      And("the 'Change organisation information' status is 'Completed'")
-      TaskListPage.verifyTaskStatus("Change organisation information", "Completed")
+      OrganisationDetailsCheckYourAnswersPage.clickConfirmAndSaveForCheckOrgDetails()*/
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
@@ -35,7 +35,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       When(
         "the 'Add organisation information' status is 'Not yet started' the user navigates to the 'Add organisation information' page"
       )
-      TaskListPage.verifyTaskStatus("Not yet started") shouldBe true
+      TaskListPage.verifyTaskStatus("Add organisation information" ,"Not yet started")
       AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
 
       Then("the user is navigated to the 'Registered ISA Manager' page")
@@ -291,7 +291,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
       And("the 'Change organisation information' status is 'Completed'")
-      TaskListPage.verifyTaskStatus("Completed") shouldBe true
+      TaskListPage.verifyTaskStatus("Change organisation information" ,"Completed")
 
     }
 
@@ -308,7 +308,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       When(
         "the 'Add organisation information' status is 'Not yet started' the user navigates to the 'Add organisation information' page"
       )
-      TaskListPage.verifyTaskStatus("Not yet started") shouldBe true
+      TaskListPage.verifyTaskStatus("Add organisation information" ,"Not yet started")
       AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
 
       // Navigation to the REgistered ISA Manager page is handled in the above code
@@ -514,7 +514,7 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
       And("the 'Change organisation information' status is 'Completed'")
-      TaskListPage.verifyTaskStatus("Completed") shouldBe true
+      TaskListPage.verifyTaskStatus("Change organisation information" ,"Completed")
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationDetailsSpec.scala
@@ -32,7 +32,10 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       Then("the user is navigated to the 'Manage ISAs' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'Registered ISA Manager' page")
+      When(
+        "the 'Add organisation information' status is 'Not yet started' the user navigates to the 'Add organisation information' page"
+      )
+      TaskListPage.verifyTaskStatus("Not yet started") shouldBe true
       AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
 
       Then("the user is navigated to the 'Registered ISA Manager' page")
@@ -261,18 +264,19 @@ class AddOrganisationDetailsSpec extends BaseSpec {
 //        CheckYourAnswersPage.pageUrl
 //      ) shouldBe true
 
-      When("the user clicks on change link for Change organisation Telephone number")
-      CheckYourAnswersPage.clickOnLinks("change-organisation-telephone-number")
-
-      Then("the user is navigated to the 'change-organisation-telephone-number' page")
-      ChangeOrganisationTelephoneNumberPage.verifyPageTitle(
-        ChangeOrganisationTelephoneNumberPage.pageTitle,
-        ChangeOrganisationTelephoneNumberPage.pageUrl
-      ) shouldBe true
-
-      Then("the user changes the organisation telephone number")
-      ChangeOrganisationTelephoneNumberPage.enterText("value", "07777777777")
-      ChangeOrganisationTelephoneNumberPage.clickSaveAndContinue()
+      // IS A DUPLICATED TEST: there is a test above which changes the phone number already
+//      When("the user clicks on change link for Change organisation Telephone number")
+//      CheckYourAnswersPage.clickOnLinks("change-organisation-telephone-number")
+//
+//      Then("the user is navigated to the 'change-organisation-telephone-number' page")
+//      ChangeOrganisationTelephoneNumberPage.verifyPageTitle(
+//        ChangeOrganisationTelephoneNumberPage.pageTitle,
+//        ChangeOrganisationTelephoneNumberPage.pageUrl
+//      ) shouldBe true
+//
+//      Then("the user changes the organisation telephone number")
+//      ChangeOrganisationTelephoneNumberPage.enterText("value", "07777777777")
+//      ChangeOrganisationTelephoneNumberPage.clickSaveAndContinue()
 
 //      Then("the user is navigated to the 'Check your answers' page")
 //      CheckYourAnswersPage.verifyPageTitle(
@@ -286,6 +290,9 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       Then("the user clicks on is navigated to the 'Manage ISAs' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
+      And("the 'Change organisation information' status is 'Completed'")
+      TaskListPage.verifyTaskStatus("Completed") shouldBe true
+
     }
 
     Scenario(
@@ -298,8 +305,15 @@ class AddOrganisationDetailsSpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'Registered ISA Manager' page")
+      When(
+        "the 'Add organisation information' status is 'Not yet started' the user navigates to the 'Add organisation information' page"
+      )
+      TaskListPage.verifyTaskStatus("Not yet started") shouldBe true
       AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
+
+      // Navigation to the REgistered ISA Manager page is handled in the above code
+//      When("the user navigates to the 'Registered ISA Manager' page")
+//      AuthLoginPage.navigateTo(RegisteredIsaManagerPage.pageUrl)
 
       Then("the user is navigated to the 'Registered ISA Manager' page")
       RegisteredIsaManagerPage.verifyPageTitle(
@@ -498,6 +512,9 @@ class AddOrganisationDetailsSpec extends BaseSpec {
 
       Then("the user clicks on is navigated to the 'Manage ISAs' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      And("the 'Change organisation information' status is 'Completed'")
+      TaskListPage.verifyTaskStatus("Completed") shouldBe true
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
@@ -30,16 +30,11 @@ class AddOrganisationEmailSpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      /* we need to put steps to add org details when navigation is available. */
-
       When(
         "the 'Add organisation email' status is 'Not yet started' the user navigates to the 'Organisation email address' page"
       )
       TaskListPage.verifyTaskStatus("Add organisation email", "Not yet started")
       TaskListPage.clickOnByPartialLinkText("Add organisation email")
-
-//      When("the user navigates to the 'Organisation email address' page")
-//      AuthLoginPage.navigateTo(OrganisationEmailAddressPage.pageUrl)
 
       Then("the user is navigated to the 'Organisation email address' page")
       OrganisationEmailAddressPage.verifyPageTitle(
@@ -88,20 +83,23 @@ class AddOrganisationEmailSpec extends BaseSpec {
       Then("the user clicks on Confirm and Save button")
       OrganisationEmailCheckYourAnswersPage.clickConfirmAndSave()
 
-      Then("the user is navigated to the 'Manage ISAs' page")
+      Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-//      When("the user navigates to the 'Check your answers' page")
-//      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
-//
-//      Then("the user is navigated to the 'Check your answers' page")
-//      CheckYourAnswersPage.verifyPageTitle(
-//        CheckYourAnswersPage.pageTitle,
-//        CheckYourAnswersPage.pageUrl
-//      ) shouldBe true
+      And(" The status for 'Organisation email' status is 'Verified'")
+      TaskListPage.verifyTaskStatus("Change organisation email", "Verified")
 
-//      When("the user clicks on change link for change organisation email address")
-//      OrganisationEmailCheckYourAnswersPage.clickOnLinks("change-organisation-email-address")
+      // below steps to be used in E2E test with nav in place
+
+      /*  When("the user navigates to the 'Check your answers' page")
+      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
+
+      Then("the user is navigated to the 'Check your answers' page")
+      CheckYourAnswersPage.verifyPageTitle(CheckYourAnswersPage.pageTitle, CheckYourAnswersPage.pageUrl
+      ) shouldBe true
+
+      When("the user clicks on change link for change organisation email address")
+      OrganisationEmailCheckYourAnswersPage.clickOnLinks("change-organisation-email-address")
 
       When("the user clicks on change link for change organisation email address")
       OrganisationEmailCheckYourAnswersPage.clickOnByPartialLinkText("Change organisation email")
@@ -115,17 +113,10 @@ class AddOrganisationEmailSpec extends BaseSpec {
       Then("the user clicks on Confirm and save button")
       ChangeOrganisationEmailAddressPage.clickConfirmAndSave()
 
-//      Then("the user is navigated to the 'Check your answers' page")
-//      CheckYourAnswersPage.verifyPageTitle(
-//        CheckYourAnswersPage.pageTitle,
-//        CheckYourAnswersPage.pageUrl
-//      ) shouldBe true
-
-      Then("the user clicks on is navigated to the 'Manage ISAs' page")
-      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
-
-      And("the 'Change organisation email' status is 'Verified'")
-      TaskListPage.verifyTaskStatus("Change organisation email", "Verified")
+      Then("the user is navigated to the 'Check your answers' page")
+      CheckYourAnswersPage.verifyPageTitle(
+      CheckYourAnswersPage.pageTitle, CheckYourAnswersPage.pageUrl
+     ) shouldBe true*/
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
@@ -32,12 +32,14 @@ class AddOrganisationEmailSpec extends BaseSpec {
 
       /* we need to put steps to add org details when navigation is available. */
 
-      When("the 'Add organisation email' status is 'Not yet started' the user navigates to the 'Organisation email address' page")
-      TaskListPage.verifyTaskStatus("Add organisation email" ,"Not yet started")
-      AuthLoginPage.navigateTo(OrganisationEmailAddressPage.pageUrl)
+      When(
+        "the 'Add organisation email' status is 'Not yet started' the user navigates to the 'Organisation email address' page"
+      )
+      TaskListPage.verifyTaskStatus("Add organisation email", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add organisation email")
 
-      When("the user navigates to the 'Organisation email address' page")
-      AuthLoginPage.navigateTo(OrganisationEmailAddressPage.pageUrl)
+//      When("the user navigates to the 'Organisation email address' page")
+//      AuthLoginPage.navigateTo(OrganisationEmailAddressPage.pageUrl)
 
       Then("the user is navigated to the 'Organisation email address' page")
       OrganisationEmailAddressPage.verifyPageTitle(
@@ -123,7 +125,7 @@ class AddOrganisationEmailSpec extends BaseSpec {
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
       And("the 'Change organisation email' status is 'Verified'")
-      TaskListPage.verifyTaskStatus("Change organisation email" ,"Verified")
+      TaskListPage.verifyTaskStatus("Change organisation email", "Verified")
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
@@ -82,35 +82,41 @@ class AddOrganisationEmailSpec extends BaseSpec {
       Then("the user clicks on Confirm and Save button")
       OrganisationEmailCheckYourAnswersPage.clickConfirmAndSave()
 
-      Then("the user is navigated to the 'Task list' page")
+      Then("the user is navigated to the 'Manage ISAs' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
-      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
+//      When("the user navigates to the 'Check your answers' page")
+//      AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
+//
+//      Then("the user is navigated to the 'Check your answers' page")
+//      CheckYourAnswersPage.verifyPageTitle(
+//        CheckYourAnswersPage.pageTitle,
+//        CheckYourAnswersPage.pageUrl
+//      ) shouldBe true
 
-      Then("the user is navigated to the 'Check your answers' page")
-      CheckYourAnswersPage.verifyPageTitle(
-        CheckYourAnswersPage.pageTitle,
-        CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+//      When("the user clicks on change link for change organisation email address")
+//      OrganisationEmailCheckYourAnswersPage.clickOnLinks("change-organisation-email-address")
 
       When("the user clicks on change link for change organisation email address")
-      OrganisationEmailCheckYourAnswersPage.clickOnLinks("change-organisation-email-address")
+      OrganisationEmailCheckYourAnswersPage.clickOnByPartialLinkText("Change organisation email")
 
-      Then("the user is navigated to the 'Change Organisation Email address' page")
+      Then("the user is navigated to the 'Check your verified organisation email' page")
       OrganisationEmailCheckYourAnswersPage.verifyPageTitle(
-        ChangeOrganisationEmailAddressPage.pageTitle,
-        ChangeOrganisationEmailAddressPage.pageUrl
+        OrganisationEmailCheckYourAnswersPage.pageTitle,
+        OrganisationEmailCheckYourAnswersPage.pageUrl
       ) shouldBe true
 
-      Then("the user clicks on Save and continue button")
-      ChangeOrganisationEmailAddressPage.clickSaveAndContinue()
+      Then("the user clicks on Confirm and save button")
+      ChangeOrganisationEmailAddressPage.clickConfirmAndSave()
 
-      Then("the user is navigated to the 'Check your answers' page")
-      CheckYourAnswersPage.verifyPageTitle(
-        CheckYourAnswersPage.pageTitle,
-        CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+//      Then("the user is navigated to the 'Check your answers' page")
+//      CheckYourAnswersPage.verifyPageTitle(
+//        CheckYourAnswersPage.pageTitle,
+//        CheckYourAnswersPage.pageUrl
+//      ) shouldBe true
+
+      Then("the user clicks on is navigated to the 'Manage ISAs' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddOrganisationEmailSpec.scala
@@ -32,6 +32,10 @@ class AddOrganisationEmailSpec extends BaseSpec {
 
       /* we need to put steps to add org details when navigation is available. */
 
+      When("the 'Add organisation email' status is 'Not yet started' the user navigates to the 'Organisation email address' page")
+      TaskListPage.verifyTaskStatus("Add organisation email" ,"Not yet started")
+      AuthLoginPage.navigateTo(OrganisationEmailAddressPage.pageUrl)
+
       When("the user navigates to the 'Organisation email address' page")
       AuthLoginPage.navigateTo(OrganisationEmailAddressPage.pageUrl)
 
@@ -117,6 +121,9 @@ class AddOrganisationEmailSpec extends BaseSpec {
 
       Then("the user clicks on is navigated to the 'Manage ISAs' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      And("the 'Change organisation email' status is 'Verified'")
+      TaskListPage.verifyTaskStatus("Change organisation email" ,"Verified")
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddSignatoryScreenSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddSignatoryScreenSpec.scala
@@ -30,8 +30,11 @@ class AddSignatoryScreenSpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("User clicks signatories link")
-      TaskListPage.clickSignatories()
+      Then(
+        "the 'Add signatories' status is 'Not yet started' the user clicks on the 'Add signatories' link"
+      )
+      TaskListPage.verifyTaskStatus("Add signatories", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add signatories")
 
       Then("the user is navigated to the 'signatory-name' page")
       SignatoryNamePage.verifyPageTitle(SignatoryNamePage.pageTitle, SignatoryNamePage.pageUrl) shouldBe true
@@ -94,7 +97,7 @@ class AddSignatoryScreenSpec extends BaseSpec {
         CheckAddedSignatoryPage.pageUrl
       ) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
+      /*  When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
       Then("the user is navigated to the 'Check your answers' page")
@@ -139,7 +142,7 @@ class AddSignatoryScreenSpec extends BaseSpec {
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+      ) shouldBe true*/
 
     }
 
@@ -151,8 +154,11 @@ class AddSignatoryScreenSpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("User clicks signatories link")
-      TaskListPage.clickSignatories()
+      Then(
+        "the 'Add signatories' status is 'Not yet started' the user clicks on the 'Add signatories' link"
+      )
+      TaskListPage.verifyTaskStatus("Add signatories", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add signatories")
 
       Then("the user is navigated to the 'signatory-name' page")
       SignatoryNamePage.verifyPageTitle(SignatoryNamePage.pageTitle, SignatoryNamePage.pageUrl) shouldBe true
@@ -266,7 +272,10 @@ class AddSignatoryScreenSpec extends BaseSpec {
       Then("the user is navigated to the 'Task-list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
+      And("The status for 'Change signatories' is '1 signatory'")
+      TaskListPage.verifyTaskStatus("Change signatories", "1 signatory")
+
+      /*  When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
       Then("the user is navigated to the 'Check your answers' page")
@@ -328,7 +337,7 @@ class AddSignatoryScreenSpec extends BaseSpec {
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+      ) shouldBe true*/
 
     }
   }

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddThirdPartySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/AddThirdPartySpec.scala
@@ -30,8 +30,11 @@ class AddThirdPartySpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'ISA products managed by third party' page")
-      AuthLoginPage.navigateTo(ThirdPartyProductManagePage.pageUrl)
+      Then(
+        "the 'Add organisations you outsource to' status is 'Not yet started' the user clicks on the 'Add organisations you outsource to' link"
+      )
+      TaskListPage.verifyTaskStatus("Add organisations you outsource to", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add organisations you outsource to")
 
       Then("the user is navigated to the 'ISA products managed by third party' page")
       ThirdPartyProductManagePage.verifyPageTitle(
@@ -195,7 +198,10 @@ class AddThirdPartySpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
+      And("The status for 'Change organisations you outsource to' is '1 third party'")
+      TaskListPage.verifyTaskStatus("Change organisations you outsource to", "1 third party")
+
+      /*  When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
       Then("the user is navigated to the 'Check your answers' page")
@@ -276,7 +282,7 @@ class AddThirdPartySpec extends BaseSpec {
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+      ) shouldBe true*/
 
     }
 
@@ -287,8 +293,11 @@ class AddThirdPartySpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'ISA products managed by third party' page")
-      AuthLoginPage.navigateTo(ThirdPartyProductManagePage.pageUrl)
+      Then(
+        "the 'Add organisations you outsource to' status is 'Not yet started' the user clicks on the 'Add organisations you outsource to' link"
+      )
+      TaskListPage.verifyTaskStatus("Add organisations you outsource to", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add organisations you outsource to")
 
       Then("the user is navigated to the 'ISA products managed by third party' page")
       ThirdPartyProductManagePage.verifyPageTitle(
@@ -475,6 +484,9 @@ class AddThirdPartySpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
+      And("The status for 'Change organisations you outsource to' is '1 third party'")
+      TaskListPage.verifyTaskStatus("Change organisations you outsource to", "1 third party")
+
     }
 
     Scenario("3.Verify user can add more than one Third party organisations and then able to connect them") {
@@ -484,8 +496,11 @@ class AddThirdPartySpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      When("the user navigates to the 'ISA products managed by third party' page")
-      AuthLoginPage.navigateTo(ThirdPartyProductManagePage.pageUrl)
+      Then(
+        "the 'Add organisations you outsource to' status is 'Not yet started' the user clicks on the 'Add organisations you outsource to' link"
+      )
+      TaskListPage.verifyTaskStatus("Add organisations you outsource to", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Add organisations you outsource to")
 
       Then("the user is navigated to the 'ISA products managed by third party' page")
       ThirdPartyProductManagePage.verifyPageTitle(
@@ -870,7 +885,10 @@ class AddThirdPartySpec extends BaseSpec {
       Then("the user is navigated to the 'Task list' page")
       TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
 
-      // Verifying change links from final CYA page
+      And("The status for 'Change organisations you outsource to' is '3 third parties'")
+      TaskListPage.verifyTaskStatus("Change organisations you outsource to", "3 third parties")
+
+      /*
       When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
@@ -927,7 +945,7 @@ class AddThirdPartySpec extends BaseSpec {
         "the user selects the second organisation from the list then clicks on save and continue to 'added third party organisation' page "
       )
       ChangeConnectedThirdPartiesPage.unselectSecondOrg()
-      ChangeConnectedThirdPartiesPage.clickSaveAndContinue()
+      ChangeConnectedThirdPartiesPage.clickSaveAndContinue()*/
 
     }
 

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/ISAManagerEligibilitySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/ISAManagerEligibilitySpec.scala
@@ -25,8 +25,17 @@ class ISAManagerEligibilitySpec extends BaseSpec {
     Scenario(
       "Verify ISA Manager eligibility Journey when they have certificate of authority and checking change links features"
     ) {
-      Given("the ISA manager is logged in as an organisation User")
-      AuthLoginPage.loginAsAFreshUser("/eligibility-to-manage-isas")
+      Given("the user is logged in as an organisation User")
+      AuthLoginPage.loginAsAFreshUser("/start")
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      Then(
+        "the 'Which certificates of authority apply to your organisation' status is 'Not yet started' the user clicks on the 'Which certificates of authority apply to your organisation' link"
+      )
+      TaskListPage.verifyTaskStatus("Which certificates of authority apply to your organisation", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Which certificates of authority apply to your organisation")
 
       Then("the 'Eligibility To Manage ISAs' Page title & url should be correct")
       EligibilityToManageIsasPage.verifyPageTitle(
@@ -91,7 +100,13 @@ class ISAManagerEligibilitySpec extends BaseSpec {
         CertificatesOfAuthorityCheckYourAnswersPage.pageUrl
       ) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
+      Then("the user clicks on Confirm and Save button")
+      OrganisationEmailCheckYourAnswersPage.clickConfirmAndSave()
+
+      And(" The status for 'Change which certificates of authority apply to your organisation' status is 'Completed'")
+      TaskListPage.verifyTaskStatus("Change which certificates of authority apply to your organisation", "Completed")
+
+      /*When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
       Then("the user is navigated to the 'Check your answers' page")
@@ -124,13 +139,22 @@ class ISAManagerEligibilitySpec extends BaseSpec {
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+      ) shouldBe true*/
 
     }
 
     Scenario("Verify ISA Manager eligibility Journey when they don't have certificate of authority") {
-      Given("the ISA manager is logged in as an organisation User")
-      AuthLoginPage.loginAsAFreshUser("/eligibility-to-manage-isas")
+      Given("the user is logged in as an organisation User")
+      AuthLoginPage.loginAsAFreshUser("/start")
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      Then(
+        "the 'Which certificates of authority apply to your organisation' status is 'Not yet started' the user clicks on the 'Which certificates of authority apply to your organisation' link"
+      )
+      TaskListPage.verifyTaskStatus("Which certificates of authority apply to your organisation", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("Which certificates of authority apply to your organisation")
 
       Then("the 'Eligibility To Manage ISAs' Page title & url should be correct")
       EligibilityToManageIsasPage.verifyPageTitle(
@@ -166,6 +190,13 @@ class ISAManagerEligibilitySpec extends BaseSpec {
         CertificatesOfAuthorityCheckYourAnswersPage.pageTitle,
         CertificatesOfAuthorityCheckYourAnswersPage.pageUrl
       ) shouldBe true
+
+      Then("the user clicks on Confirm and Save button")
+      OrganisationEmailCheckYourAnswersPage.clickConfirmAndSave()
+
+      And(" The status for 'Change which certificates of authority apply to your organisation' status is 'Completed'")
+      TaskListPage.verifyTaskStatus("Change which certificates of authority apply to your organisation", "Completed")
+
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/ISAManagerRegistrationProductsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/ISAManagerRegistrationProductsSpec.scala
@@ -23,8 +23,17 @@ class ISAManagerRegistrationProductsSpec extends BaseSpec {
   Feature("ISA manager Registration") {
 
     Scenario("Verify ISA Manager registration products Journey and verifying change links") {
-      Given("the ISA manager is logged in as an organisation User")
-      AuthLoginPage.loginAsAFreshUser("/isa-products")
+      Given("the user is logged in as an organisation User")
+      AuthLoginPage.loginAsAFreshUser("/start")
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      Then(
+        "the 'ISA products you manage' status is 'Not yet started' the user clicks on the 'ISA products you manage' link"
+      )
+      TaskListPage.verifyTaskStatus("ISA products you manage", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("ISA products you manage")
 
       Then("the 'ISA Products' page title & url should be correct")
       ISAProductsPage.verifyPageTitle(ISAProductsPage.pageTitle, ISAProductsPage.pageUrl) shouldBe true
@@ -83,7 +92,13 @@ class ISAManagerRegistrationProductsSpec extends BaseSpec {
         IsaProductsCheckYourAnswersPage.pageUrl
       ) shouldBe true
 
-      When("the user navigates to the 'Check your answers' page")
+      Then("the user clicks on Confirm and Save button")
+      OrganisationEmailCheckYourAnswersPage.clickConfirmAndSave()
+
+      And(" The status for 'Change ISA products you manage' status is 'Completed'")
+      TaskListPage.verifyTaskStatus("Change ISA products you manage", "Completed")
+
+      /* When("the user navigates to the 'Check your answers' page")
       AuthLoginPage.navigateTo(CheckYourAnswersPage.pageUrl)
 
       Then("the user is navigated to the 'Check your answers' page")
@@ -120,9 +135,9 @@ class ISAManagerRegistrationProductsSpec extends BaseSpec {
       ) shouldBe true
 
       Then("the user clicks on save and continue on 'change-innovative-financial-products' page")
-      ChangeInnovativeFinancialProductsPage.clickSaveAndContinue()
+      ChangeInnovativeFinancialProductsPage.clickSaveAndContinue()*/
 
-      Then("the user is navigated to the 'Check your answers' page")
+      /*Then("the user is navigated to the 'Check your answers' page")
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
@@ -168,12 +183,21 @@ class ISAManagerRegistrationProductsSpec extends BaseSpec {
       CheckYourAnswersPage.verifyPageTitle(
         CheckYourAnswersPage.pageTitle,
         CheckYourAnswersPage.pageUrl
-      ) shouldBe true
+      ) shouldBe true*/
     }
 
     Scenario("Verify ISA Manager registration Journey without peer to peer loans using a platform") {
-      Given("the ISA manager is logged in as an organisation User")
-      AuthLoginPage.loginAsAFreshUser("/isa-products")
+      Given("the user is logged in as an organisation User")
+      AuthLoginPage.loginAsAFreshUser("/start")
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      Then(
+        "the 'ISA products you manage' status is 'Not yet started' the user clicks on the 'ISA products you manage' link"
+      )
+      TaskListPage.verifyTaskStatus("ISA products you manage", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("ISA products you manage")
 
       Then("the 'ISA Products' page title & url should be correct")
       ISAProductsPage.verifyPageTitle(ISAProductsPage.pageTitle, ISAProductsPage.pageUrl) shouldBe true

--- a/src/test/scala/uk/gov/hmrc/ui/disa/specs/SignOutSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ui/disa/specs/SignOutSpec.scala
@@ -25,8 +25,17 @@ class SignOutSpec extends BaseSpec {
     Scenario(
       "Verify 'saved answers sign out page' displayed correctly for the users who already saved answers and logs out"
     ) {
-      Given("the ISA manager is logged in as an organisation User")
-      AuthLoginPage.loginAsAFreshUser("/isa-products")
+      Given("the user is logged in as an organisation User")
+      AuthLoginPage.loginAsAFreshUser("/start")
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      Then(
+        "the 'ISA products you manage' status is 'Not yet started' the user clicks on the 'ISA products you manage' link"
+      )
+      TaskListPage.verifyTaskStatus("ISA products you manage", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("ISA products you manage")
 
       Then("The 'ISA Products' page title & url should be correct")
       ISAProductsPage.verifyPageTitle(ISAProductsPage.pageTitle, ISAProductsPage.pageUrl) shouldBe true
@@ -60,8 +69,17 @@ class SignOutSpec extends BaseSpec {
     Scenario(
       "Verify 'sign out page' displayed correctly for the users who logs out without saving any answer"
     ) {
-      Given("the ISA manager is logged in as an organisation User")
-      AuthLoginPage.loginAsAFreshUser("/isa-products")
+      Given("the user is logged in as an organisation User")
+      AuthLoginPage.loginAsAFreshUser("/start")
+
+      Then("the user is navigated to the 'Task list' page")
+      TaskListPage.verifyPageTitle(TaskListPage.pageTitle, TaskListPage.pageUrl) shouldBe true
+
+      Then(
+        "the 'ISA products you manage' status is 'Not yet started' the user clicks on the 'ISA products you manage' link"
+      )
+      TaskListPage.verifyTaskStatus("ISA products you manage", "Not yet started")
+      TaskListPage.clickOnByPartialLinkText("ISA products you manage")
 
       Then("The 'ISA Products' page title & url should be correct")
       ISAProductsPage.verifyPageTitle(ISAProductsPage.pageTitle, ISAProductsPage.pageUrl) shouldBe true


### PR DESCRIPTION
For this PR we have refactored the automation tests so it follows the new flow. Where all the tasks the user needs to complete are now on one page, the task list page.

The new automation tests are adding verification for a couple of items, such as the checking all the tasks are present, the status before and after each of those tasks i.e. 'Not yet started' to 'Completed' or another completion message, the name change after the tasks have been completed i.e. Add organisation email' to 'Change organisation email'.